### PR TITLE
feat: make `createWorkerFixture` use object as an argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,18 +6,18 @@ import {
   getResponse,
 } from 'msw'
 
-export interface WorkerFixtureProps {
+export interface CreateWorkerFixtureArgs {
   initialHandlers: Array<RequestHandler>
 }
 
 export function createWorkerFixture(
-  { initialHandlers }: WorkerFixtureProps = { initialHandlers: [] },
+  args: CreateWorkerFixtureArgs,
   /** @todo `onUnhandledRequest`? */
 ): TestFixture<WorkerFixture, any> {
   return async ({ page }, use) => {
     const worker = new WorkerFixture({
       page,
-      initialHandlers,
+      initialHandlers: args.initialHandlers,
     })
 
     await worker.start()
@@ -30,7 +30,7 @@ export class WorkerFixture extends SetupApi<LifeCycleEventsMap> {
   #page: Page
 
   constructor(args: { page: Page; initialHandlers: Array<RequestHandler> }) {
-    super(...args.initialHandlers)
+    super(...(args.initialHandlers || []))
     this.#page = args.page
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,12 @@ import {
   getResponse,
 } from 'msw'
 
+export interface WorkerFixtureProps {
+  initialHandlers: Array<RequestHandler>
+}
+
 export function createWorkerFixture(
-  initialHandlers: Array<RequestHandler> = [],
+  { initialHandlers }: WorkerFixtureProps = { initialHandlers: [] },
   /** @todo `onUnhandledRequest`? */
 ): TestFixture<WorkerFixture, any> {
   return async ({ page }, use) => {


### PR DESCRIPTION
## Description
This pull request refactors the createWorkerFixture function by introducing a new interface, WorkerFixtureProps.

## Justification
The current API for createWorkerFixture doesn't align with the usage suggested in the `README.md` file. This change updates the function's signature to match the documented example, improving consistency and developer experience.
**Before:**
The createWorkerFixture function accepted initialHandlers as a direct, unnamed argument.

**After:**
The function now accepts an object conforming to the WorkerFixtureProps interface, making the initialHandlers parameter explicit and named, as shown in the README.md usage

Extracted from README.md
```ts
// playwright.setup.ts
import { test as testBase } from '@playwright/test'
import { createWorkerFixture, type WorkerFixture } from '@msw/playwright'
import { handlers } from '../mocks/handlers.js'

interface Fixtures {
  worker: WorkerFixture
}

export const test = testBase.extend<Fixtures>({
  // Create your worker fixture to access in tests.
  worker: createWorkerFixture({
    initialHandlers: handlers,
  }),
})
```
