### PR TITLE
feat: support WebSockets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - main
   pull_request:
     branches:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -65,9 +65,3 @@ test('displays the user dashboard', async ({ worker, page }) => {
   await page.goto('/dashboard')
 })
 ```
-
-## Limitations
-
-### WebSocket support
-
-This library _does not support mocking WebSockets_ at the moment. That support requires a refactoring on MSW side to expose `handleWebSocketEvent()` and simplify its call signature (it really only needs the client url). Once that refactoring is done, we will use `page.routeWebSocket()` to provision the WebSocket support.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@mswjs/interceptors": "^0.39.1"
+    "@mswjs/interceptors": "^0.39.1",
+    "outvariant": "^1.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "msw": "^2.9.0"
+    "msw": "^2.10.1"
   },
   "devDependencies": {
     "@ossjs/release": "^0.8.1",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.29",
-    "msw": "https://pkg.pr.new/msw@df2b35b",
+    "msw": "^2.10.1",
     "tsdown": "^0.12.7",
     "typescript": "^5.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "msw": "^2.10.1"
   },
   "devDependencies": {
+    "@epic-web/test-server": "^0.1.6",
     "@ossjs/release": "^0.8.1",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.29",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,11 @@
     "@ossjs/release": "^0.8.1",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.29",
-    "msw": "^2.9.0",
+    "msw": "https://pkg.pr.new/msw@df2b35b",
     "tsdown": "^0.12.7",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@mswjs/interceptors": "^0.39.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@mswjs/interceptors": "^0.39.1",
+    "@mswjs/interceptors": "^0.39.2",
     "outvariant": "^1.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@mswjs/interceptors':
+        specifier: ^0.39.1
+        version: 0.39.1
     devDependencies:
       '@ossjs/release':
         specifier: ^0.8.1
@@ -18,8 +22,8 @@ importers:
         specifier: ^22.15.29
         version: 22.15.29
       msw:
-        specifier: ^2.9.0
-        version: 2.9.0(@types/node@22.15.29)(typescript@5.8.3)
+        specifier: https://pkg.pr.new/msw@df2b35b
+        version: https://pkg.pr.new/msw@df2b35b(@types/node@22.15.29)(typescript@5.8.3)
       tsdown:
         specifier: ^0.12.7
         version: 0.12.7(typescript@5.8.3)
@@ -117,8 +121,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@mswjs/interceptors@0.38.7':
-    resolution: {integrity: sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==}
+  '@mswjs/interceptors@0.39.1':
+    resolution: {integrity: sha512-f/OVak8vv5LCi85wPDOUpqgAQV4qoZTr4H/pPuRggtdzgnU4+BYBv0+gK853ln//PDL7mUkAkR2kW313Tu1i8g==}
     engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.10':
@@ -611,8 +615,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.9.0:
-    resolution: {integrity: sha512-fNyrJ11YNbe2zl64EwtxM5OFkInFPAw5vipOljMsf9lY2ep9B2BslqQrS8EC9pB9961K61FqTUi0wsdqk6hwow==}
+  msw@https://pkg.pr.new/msw@df2b35b:
+    resolution: {tarball: https://pkg.pr.new/msw@df2b35b}
+    version: 2.9.0
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -1052,7 +1057,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mswjs/interceptors@0.38.7':
+  '@mswjs/interceptors@0.39.1':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -1491,13 +1496,13 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3):
+  msw@https://pkg.pr.new/msw@df2b35b(@types/node@22.15.29)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
       '@inquirer/confirm': 5.1.12(@types/node@22.15.29)
-      '@mswjs/interceptors': 0.38.7
+      '@mswjs/interceptors': 0.39.1
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3
     devDependencies:
+      '@epic-web/test-server':
+        specifier: ^0.1.6
+        version: 0.1.6
       '@ossjs/release':
         specifier: ^0.8.1
         version: 0.8.1
@@ -74,6 +77,23 @@ packages:
 
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@epic-web/test-server@0.1.6':
+    resolution: {integrity: sha512-n6+dZKI2I3J8f3vjIFAYh5trgAJl0crji76+K1aoiRJqEYjdsCX/nVgBrkBCwPpBqhv9NZ1XlMqzfOafkqY5EQ==}
+    engines: {node: '>=20'}
+
+  '@hono/node-server@1.14.4':
+    resolution: {integrity: sha512-DnxpshhYewr2q9ZN8ez/M5mmc3sucr8CT1sIgIy1bkeUXut9XWDkqHoFHRhWIQgkYnKpVRxunyhK7WzpJeJ6qQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-ws@1.1.6':
+    resolution: {integrity: sha512-8ab2e0sr5FUbQJVYo0OxzaToQkiyeA9pOkLauzWHYNKfarhQ7XlISWsM3lShQYOOgrWpgXXxr1FTXXE0V7P/uw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      '@hono/node-server': ^1.11.1
+      hono: ^4.6.0
 
   '@inquirer/confirm@5.1.12':
     resolution: {integrity: sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==}
@@ -261,6 +281,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -528,6 +551,10 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  hono@4.7.11:
+    resolution: {integrity: sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -944,6 +971,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -1015,6 +1054,31 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@epic-web/test-server@0.1.6':
+    dependencies:
+      '@hono/node-server': 1.14.4(hono@4.7.11)
+      '@hono/node-ws': 1.1.6(@hono/node-server@1.14.4(hono@4.7.11))(hono@4.7.11)
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/ws': 8.18.1
+      hono: 4.7.11
+      ws: 8.18.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@hono/node-server@1.14.4(hono@4.7.11)':
+    dependencies:
+      hono: 4.7.11
+
+  '@hono/node-ws@1.1.6(@hono/node-server@1.14.4(hono@4.7.11))(hono@4.7.11)':
+    dependencies:
+      '@hono/node-server': 1.14.4(hono@4.7.11)
+      hono: 4.7.11
+      ws: 8.18.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@inquirer/confirm@5.1.12(@types/node@22.15.29)':
     dependencies:
@@ -1200,6 +1264,10 @@ snapshots:
   '@types/statuses@2.0.5': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.15.29
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -1437,6 +1505,8 @@ snapshots:
       function-bind: 1.1.2
 
   headers-polyfill@4.0.3: {}
+
+  hono@4.7.11: {}
 
   hookable@5.5.3: {}
 
@@ -1849,6 +1919,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.18.2: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^22.15.29
         version: 22.15.29
       msw:
-        specifier: https://pkg.pr.new/msw@df2b35b
-        version: https://pkg.pr.new/msw@df2b35b(@types/node@22.15.29)(typescript@5.8.3)
+        specifier: ^2.10.1
+        version: 2.10.1(@types/node@22.15.29)(typescript@5.8.3)
       tsdown:
         specifier: ^0.12.7
         version: 0.12.7(typescript@5.8.3)
@@ -615,9 +615,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@https://pkg.pr.new/msw@df2b35b:
-    resolution: {tarball: https://pkg.pr.new/msw@df2b35b}
-    version: 2.9.0
+  msw@2.10.1:
+    resolution: {integrity: sha512-V/YhZE2QPd48vKFGLo2BZanbBqncJn2k9/+vGtq9IFtv2D78+DIXlKH63emxa8reE/LIQHz9p3ZcFOThhsTSOg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -1496,7 +1495,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@https://pkg.pr.new/msw@df2b35b(@types/node@22.15.29)(typescript@5.8.3):
+  msw@2.10.1(@types/node@22.15.29)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@mswjs/interceptors':
-        specifier: ^0.39.1
-        version: 0.39.1
+        specifier: ^0.39.2
+        version: 0.39.2
       outvariant:
         specifier: ^1.4.3
         version: 1.4.3
@@ -144,8 +144,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@mswjs/interceptors@0.39.1':
-    resolution: {integrity: sha512-f/OVak8vv5LCi85wPDOUpqgAQV4qoZTr4H/pPuRggtdzgnU4+BYBv0+gK853ln//PDL7mUkAkR2kW313Tu1i8g==}
+  '@mswjs/interceptors@0.39.2':
+    resolution: {integrity: sha512-RuzCup9Ct91Y7V79xwCb146RaBRHZ7NBbrIUySumd1rpKqHL5OonaqrGIbug5hNwP/fRyxFMA6ISgw4FTtYFYg==}
     engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.10':
@@ -1123,7 +1123,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mswjs/interceptors@0.39.1':
+  '@mswjs/interceptors@0.39.2':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -1574,7 +1574,7 @@ snapshots:
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
       '@inquirer/confirm': 5.1.12(@types/node@22.15.29)
-      '@mswjs/interceptors': 0.39.1
+      '@mswjs/interceptors': 0.39.2
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mswjs/interceptors':
         specifier: ^0.39.1
         version: 0.39.1
+      outvariant:
+        specifier: ^1.4.3
+        version: 1.4.3
     devDependencies:
       '@ossjs/release':
         specifier: ^0.8.1

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@mswjs/interceptors/WebSocket'
 
 export interface CreateWorkerFixtureArgs {
-  initialHandlers: Array<RequestHandler>
+  initialHandlers: Array<RequestHandler | WebSocketHandler>
 }
 
 export function createWorkerFixture(
@@ -37,7 +37,10 @@ export function createWorkerFixture(
 export class WorkerFixture extends SetupApi<LifeCycleEventsMap> {
   #page: Page
 
-  constructor(args: { page: Page; initialHandlers: Array<RequestHandler> }) {
+  constructor(args: {
+    page: Page
+    initialHandlers: Array<RequestHandler | WebSocketHandler>
+  }) {
     super(...args.initialHandlers)
     this.#page = args.page
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import {
   type LifeCycleEventsMap,
   SetupApi,
   RequestHandler,
-  getResponse,
   WebSocketHandler,
+  getResponse,
 } from 'msw'
 import {
   type WebSocketClientEventMap,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,18 @@
-import type { Page, TestFixture } from '@playwright/test'
+import type { Page, TestFixture, WebSocketRoute } from '@playwright/test'
 import {
   type LifeCycleEventsMap,
   SetupApi,
   RequestHandler,
   getResponse,
+  WebSocketHandler,
 } from 'msw'
+import {
+  type WebSocketClientEventMap,
+  type WebSocketData,
+  type WebSocketServerEventMap,
+  WebSocketClientConnectionProtocol,
+  WebSocketServerConnectionProtocol,
+} from '@mswjs/interceptors/WebSocket'
 
 export interface CreateWorkerFixtureArgs {
   initialHandlers: Array<RequestHandler>
@@ -35,6 +43,7 @@ export class WorkerFixture extends SetupApi<LifeCycleEventsMap> {
   }
 
   public async start() {
+    // Handle HTTP requests.
     await this.#page.route(/.+/, async (route, request) => {
       const fetchRequest = new Request(request.url(), {
         method: request.method(),
@@ -62,10 +71,199 @@ export class WorkerFixture extends SetupApi<LifeCycleEventsMap> {
 
       route.continue()
     })
+
+    // Handle WebSocket connections.
+    this.#page.routeWebSocket(/.+/, async (ws) => {
+      const allWebSocketHandlers = this.handlersController
+        .currentHandlers()
+        .filter((handler) => {
+          return handler instanceof WebSocketHandler
+        })
+
+      if (allWebSocketHandlers.length === 0) {
+        ws.connectToServer()
+        return
+      }
+
+      const client = new PlaywrightWebSocketClientConnection(ws)
+      const server = new PlaywrightWebSocketServerConnection(ws)
+
+      for (const handler of allWebSocketHandlers) {
+        handler.run({
+          client,
+          server,
+          info: { protocols: [] },
+        })
+      }
+    })
   }
 
   public async stop() {
     super.dispose()
     await this.#page.unroute(/.+/)
+  }
+}
+
+class PlaywrightWebSocketClientConnection
+  implements WebSocketClientConnectionProtocol
+{
+  public id: string
+  public url: URL
+
+  constructor(protected readonly ws: WebSocketRoute) {
+    this.id = crypto.randomUUID()
+    this.url = new URL(ws.url())
+  }
+
+  public send(data: WebSocketData): void {
+    /**
+     * @note Playwright type definitions are tailored to Node.js
+     * while MSW describes all data types that can be sent over
+     * the WebSocket protocol.
+     */
+    this.ws.send(data as any)
+  }
+
+  public close(code?: number, reason?: string): void {
+    this.ws.close({ code, reason })
+  }
+
+  public addEventListener<EventType extends keyof WebSocketClientEventMap>(
+    type: EventType,
+    listener: (
+      this: WebSocket,
+      event: WebSocketClientEventMap[EventType],
+    ) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    /**
+     * @note Playwright does not expose the actual WebSocket reference.
+     */
+    const target = {} as WebSocket
+
+    if (typeof options === 'object' && options?.once) {
+      console.warn(
+        '@msw/playwright: WebSocketRoute from Playwright does not support "once" option',
+      )
+    }
+
+    switch (type) {
+      case 'message': {
+        this.ws.onMessage((data) => {
+          listener.call(
+            target,
+            new MessageEvent('message', {
+              data,
+            }) as any,
+          )
+        })
+        break
+      }
+
+      case 'close': {
+        this.ws.onClose((code, reason) => {
+          listener.call(
+            target,
+            new CloseEvent('close', { code, reason }) as any,
+          )
+        })
+        break
+      }
+    }
+  }
+
+  public removeEventListener<EventType extends keyof WebSocketClientEventMap>(
+    event: EventType,
+    listener: (
+      this: WebSocket,
+      event: WebSocketClientEventMap[EventType],
+    ) => void,
+    options?: EventListenerOptions | boolean,
+  ): void {
+    console.warn(
+      '@msw/playwright: WebSocketRoute does not support removing event listeners',
+    )
+  }
+}
+
+class PlaywrightWebSocketServerConnection
+  implements WebSocketServerConnectionProtocol
+{
+  #server?: WebSocketRoute
+
+  constructor(protected readonly ws: WebSocketRoute) {}
+
+  public connect(): void {
+    this.#server = this.ws.connectToServer()
+  }
+
+  public send(data: WebSocketData): void {
+    if (!this.#server) {
+      //
+      return
+    }
+
+    this.#server.send(data as any)
+  }
+
+  public close(code?: number, reason?: string): void {
+    if (!this.#server) {
+      //
+      return
+    }
+
+    this.#server.close({ code, reason })
+  }
+
+  public addEventListener<EventType extends keyof WebSocketServerEventMap>(
+    event: EventType,
+    listener: (
+      this: WebSocket,
+      event: WebSocketServerEventMap[EventType],
+    ) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    if (!this.#server) {
+      return
+    }
+
+    if (typeof options === 'object' && options?.once) {
+      console.warn(
+        '@msw/playwright: WebSocketRoute from Playwright does not support "once" option',
+      )
+    }
+
+    const target = {} as WebSocket
+    switch (event) {
+      case 'message': {
+        this.#server.onMessage((data) => {
+          listener.call(target, new MessageEvent('message', { data }) as any)
+        })
+        break
+      }
+
+      case 'close': {
+        this.#server.onClose((code, reason) => {
+          listener.call(
+            target,
+            new CloseEvent('close', { code, reason }) as any,
+          )
+        })
+        break
+      }
+    }
+  }
+
+  public removeEventListener<EventType extends keyof WebSocketServerEventMap>(
+    event: EventType,
+    listener: (
+      this: WebSocket,
+      event: WebSocketServerEventMap[EventType],
+    ) => void,
+    options?: EventListenerOptions | boolean,
+  ): void {
+    console.warn(
+      '@msw/playwright: WebSocketRoute does not support removing event listeners',
+    )
   }
 }

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -18,6 +18,7 @@ test('intercepts a GET request', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   await page.evaluate(async () => {
     fetch('http://localhost/resource', {
       headers: {
@@ -43,6 +44,7 @@ test('intercepts a POST request without any body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   await page.evaluate(async () => {
     fetch('http://localhost/action', {
       method: 'POST',
@@ -64,6 +66,7 @@ test('intercepts a POST request with text body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   await page.evaluate(async () => {
     fetch('http://localhost/action', {
       method: 'POST',
@@ -88,6 +91,7 @@ test('intercepts a POST request with array buffer body', async ({
     }),
   )
 
+  await page.goto('')
   await page.evaluate(async () => {
     fetch('http://localhost/action', {
       method: 'POST',

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -17,6 +17,7 @@ test('mocks a response without any body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   const response = await page.evaluate(() => {
     return fetch('http://localhost/null').then((response) => {
       return response.text()
@@ -37,6 +38,7 @@ test('mocks a response with a text body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   const response = await page.evaluate(() => {
     return fetch('http://localhost/text').then((response) => response.text())
   })
@@ -51,6 +53,7 @@ test('mocks a response with a json body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   const response = await page.evaluate(() => {
     return fetch('http://localhost/json').then((response) => response.json())
   })
@@ -67,6 +70,7 @@ test('mocks a response with an ArrayBuffer body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   const response = await page.evaluate(() => {
     return (
       fetch('http://localhost/arrayBuffer')
@@ -90,6 +94,7 @@ test('mocks a response with an FormData body', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   const response = await page.evaluate(() => {
     return fetch('http://localhost/formData')
       .then((response) => response.formData())
@@ -114,6 +119,7 @@ test('mocks a response with a stream', async ({ worker, page }) => {
     }),
   )
 
+  await page.goto('')
   const response = await page.evaluate(() => {
     return fetch('http://localhost/stream').then((response) => response.text())
   })

--- a/tests/websockets.test.ts
+++ b/tests/websockets.test.ts
@@ -1,4 +1,6 @@
 import { test as testBase, expect } from '@playwright/test'
+import { createTestHttpServer } from '@epic-web/test-server/http'
+import { createWebSocketMiddleware } from '@epic-web/test-server/ws'
 import { ws } from 'msw'
 import { createWorkerFixture, type WorkerFixture } from '../src/index.js'
 
@@ -169,4 +171,42 @@ test('closes the client connection with a non-configurable code', async ({
     code: 1003,
     reason: '',
   })
+})
+
+test('connects to the actual server', async ({ worker, page }) => {
+  await using httpServer = await createTestHttpServer({
+    protocols: ['http']
+  })
+  await using wss = createWebSocketMiddleware({
+    server: httpServer,
+    pathname: '/ws'
+  })
+
+  wss.on('connection', (ws) => {
+    ws.addEventListener('message', (event) => {
+      console.log('server received:', event.data)
+    })
+  })
+
+  const wsUrl = wss.ws.url().href
+  const link = ws.link(wsUrl)
+  worker.use(
+    link.addEventListener('connection', ({ server }) => {
+      server.connect()
+      server.send('hello from the client')
+    })
+  )
+
+  await page.goto('')
+
+   const wasOpened = await page.evaluate((wsUrl) => {
+    const ws = new WebSocket(wsUrl)
+
+    return new Promise<boolean>((resolve, reject) => {
+      ws.onerror = () => reject(new Error('WebSocket connection failed'))
+      ws.onopen = () => resolve(true)
+    })
+  }, wsUrl)
+
+  expect(wasOpened).toBe(true)
 })

--- a/tests/websockets.test.ts
+++ b/tests/websockets.test.ts
@@ -1,0 +1,36 @@
+import { test as testBase, expect } from '@playwright/test'
+import { ws } from 'msw'
+import { createWorkerFixture, type WorkerFixture } from '../src/index.js'
+
+interface Fixtures {
+  worker: WorkerFixture
+}
+
+const test = testBase.extend<Fixtures>({
+  worker: createWorkerFixture(),
+})
+
+const api = ws.link('ws://localhost/api')
+
+test('sends a mocked event to the client', async ({ worker, page }) => {
+  worker.use(
+    api.addEventListener('connection', ({ client }) => {
+      console.log('WS CONNECTION!')
+
+      client.send('hello world')
+    }),
+  )
+
+  const message = await page.evaluate(() => {
+    const ws = new WebSocket('ws://localhost/api')
+
+    return new Promise<string>((resolve, reject) => {
+      ws.onerror = () => reject(new Error('WebSocket connection failed'))
+      ws.onmessage = (event) => {
+        resolve(event.data)
+      }
+    })
+  })
+
+  expect(message).toBe('hello world')
+})

--- a/tests/websockets.test.ts
+++ b/tests/websockets.test.ts
@@ -19,16 +19,20 @@ test('sends a mocked event to the client', async ({ worker, page }) => {
     }),
   )
 
-  const message = await page.evaluate(() => {
-    const ws = new WebSocket('ws://localhost/api')
+  await page.goto('')
 
-    return new Promise<string>((resolve, reject) => {
-      ws.onerror = () => reject(new Error('WebSocket connection failed'))
-      ws.onmessage = (event) => {
-        resolve(event.data)
-      }
+  const message = await page
+    .evaluate(() => {
+      const ws = new WebSocket('ws://localhost/api')
+
+      return new Promise<string>((resolve, reject) => {
+        ws.onerror = () => reject(new Error('WebSocket connection failed'))
+        ws.onmessage = (event) => {
+          resolve(event.data)
+        }
+      })
     })
-  })
+    .catch(() => void 0)
 
   expect(message).toBe('hello world')
 })

--- a/tests/websockets.test.ts
+++ b/tests/websockets.test.ts
@@ -15,8 +15,6 @@ const api = ws.link('ws://localhost/api')
 test('sends a mocked event to the client', async ({ worker, page }) => {
   worker.use(
     api.addEventListener('connection', ({ client }) => {
-      console.log('WS CONNECTION!')
-
       client.send('hello world')
     }),
   )

--- a/tests/websockets.test.ts
+++ b/tests/websockets.test.ts
@@ -182,9 +182,10 @@ test('connects to the actual server', async ({ worker, page }) => {
     pathname: '/ws'
   })
 
+  const serverMessage = Promise.withResolvers<string>()
   wss.on('connection', (ws) => {
     ws.addEventListener('message', (event) => {
-      console.log('server received:', event.data)
+      serverMessage.resolve(event.data?.toString())
     })
   })
 
@@ -209,4 +210,5 @@ test('connects to the actual server', async ({ worker, page }) => {
   }, wsUrl)
 
   expect(wasOpened).toBe(true)
+  await expect(serverMessage.promise).resolves.toBe('hello from the client')
 })

--- a/tests/websockets.test.ts
+++ b/tests/websockets.test.ts
@@ -12,7 +12,7 @@ const test = testBase.extend<Fixtures>({
 
 const api = ws.link('ws://localhost/api')
 
-test('sends a mocked event to the client', async ({ worker, page }) => {
+test('sends a text data to the client', async ({ worker, page }) => {
   worker.use(
     api.addEventListener('connection', ({ client }) => {
       client.send('hello world')
@@ -33,6 +33,34 @@ test('sends a mocked event to the client', async ({ worker, page }) => {
       })
     })
     .catch(() => void 0)
+
+  expect(message).toBe('hello world')
+})
+
+test('sends a buffer data to the client', async ({ worker, page }) => {
+  worker.use(
+    api.addEventListener('connection', ({ client }) => {
+      client.send(new TextEncoder().encode('hello world'))
+    }),
+  )
+
+  await page.goto('')
+
+  const message = await page.evaluate(() => {
+    const ws = new WebSocket('ws://localhost/api')
+
+    return new Promise<string>((resolve, reject) => {
+      ws.onerror = () => reject(new Error('WebSocket connection failed'))
+      ws.onmessage = async (event) => {
+        /**
+         * @note Playwright translates Buffer data to Blob.
+         */
+        if (event.data instanceof Blob) {
+          resolve(await event.data.text())
+        }
+      }
+    })
+  })
 
   expect(message).toBe('hello world')
 })


### PR DESCRIPTION
- Closes #2 

## Roadmap

- [x] `page.routeWebSocket()` isn't firing in the added test.
- [x] Expose a `createCloseEvent()` utility from `@mswjs/interceptors` so it's less tedious to create proper close events in Node.js. 