### PR TITLE
fix: export `NetworkFixture` class as value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export {
   type CreateNetworkFixtureArgs,
-  type NetworkFixture,
+  NetworkFixture,
   createNetworkFixture,
 } from './fixture.js'


### PR DESCRIPTION
Before version _v0.4.3_ the class `NetworkFixture` was exposed as a full export. #17 changed it to a type-only export, which results in the class no longer being exported from JS (only its type definitions file).

In my use-case I need to construct the handlers passed to the network fixture from another Playwright fixture. Therefore, using the provided high-level `createNetworkFixture` function to create the fixture does not work in this case. 

```ts
network: [
  async ({ page, store, baseURL }, use) => {
    const worker = new NetworkFixture({
      page,
      initialHandlers: defineHandlers(store, baseURL!),
    });
    await worker.start();
    await use(worker);
    await worker.stop();
  },
  { auto: true },
],
```