### PR TITLE
feat!: implement new `defineNetworkFixture` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,24 @@ interface Fixtures {
   network: NetworkFixture
 }
 
-export const test = testBase.extend<Fixtures>({
-  // Create a fixture that will control the network in your tests.
-  network: createNetworkFixture({
-    initialHandlers: handlers,
-  }),
+const test = testBase.extend<Fixtures>({
+  // Initial list of the network handlers.
+  handlers: [[], { option: true }],
+
+  // A fixture you use to control the network in your tests.
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "msw": "^2.12.9"
+    "msw": "^2.12.10"
   },
   "devDependencies": {
     "@epic-web/test-server": "^0.1.6",
@@ -50,7 +50,7 @@
     "@playwright/test": "^1.58.1",
     "@types/node": "^22.15.29",
     "@types/sinon": "^21.0.0",
-    "msw": "^2.12.9",
+    "msw": "^2.12.10",
     "sinon": "^21.0.1",
     "tsdown": "^0.12.7",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^21.0.0
         version: 21.0.0
       msw:
-        specifier: ^2.12.9
-        version: 2.12.9(@types/node@22.15.29)(typescript@5.9.3)
+        specifier: ^2.12.10
+        version: 2.12.10(@types/node@22.15.29)(typescript@5.9.3)
       sinon:
         specifier: ^21.0.1
         version: 21.0.1
@@ -888,8 +888,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.12.9:
-    resolution: {integrity: sha512-NYbi51C6M3dujGmcmuGemu68jy12KqQPoVWGeroKToLGsBgrwG5ErM8WctoIIg49/EV49SEvYM9WSqO4G7kNeQ==}
+  msw@2.12.10:
+    resolution: {integrity: sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -2022,7 +2022,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.9(@types/node@22.15.29)(typescript@5.9.3):
+  msw@2.12.10(@types/node@22.15.29)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@22.15.29)
       '@mswjs/interceptors': 0.41.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  type CreateNetworkFixtureArgs,
+  defineNetworkFixture,
   type NetworkFixture,
-  createNetworkFixture,
+  type NetworkFixtureOptions,
 } from './fixture.js'

--- a/tests/multiple-pages.test.ts
+++ b/tests/multiple-pages.test.ts
@@ -1,13 +1,27 @@
 import { test as testBase, expect } from '@playwright/test'
-import { http, HttpResponse, ws } from 'msw'
-import { createNetworkFixture, type NetworkFixture } from '../src/index.js'
+import { http, HttpResponse, ws, type AnyHandler } from 'msw'
+import { defineNetworkFixture, type NetworkFixture } from '../src/index.js'
 
 interface Fixtures {
+  handlers: Array<AnyHandler>
   network: NetworkFixture
 }
 
 const test = testBase.extend<Fixtures>({
-  network: createNetworkFixture(),
+  handlers: [[], { option: true }],
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 
 test('intercepts an HTTP request on a programmatically created page', async ({

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1,13 +1,27 @@
 import { test as testBase, expect } from '@playwright/test'
-import { http, HttpResponse } from 'msw'
-import { createNetworkFixture, type NetworkFixture } from '../src/index.js'
+import { http, HttpResponse, type AnyHandler } from 'msw'
+import { defineNetworkFixture, type NetworkFixture } from '../src/index.js'
 
 interface Fixtures {
+  handlers: Array<AnyHandler>
   network: NetworkFixture
 }
 
 const test = testBase.extend<Fixtures>({
-  network: createNetworkFixture(),
+  handlers: [[], { option: true }],
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 
 test.beforeEach(({ network }) => {

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -1,13 +1,27 @@
 import { test as testBase, expect } from '@playwright/test'
-import { http } from 'msw'
-import { createNetworkFixture, type NetworkFixture } from '../src/index.js'
+import { http, type AnyHandler } from 'msw'
+import { defineNetworkFixture, type NetworkFixture } from '../src/index.js'
 
 interface Fixtures {
+  handlers: Array<AnyHandler>
   network: NetworkFixture
 }
 
 const test = testBase.extend<Fixtures>({
-  network: createNetworkFixture(),
+  handlers: [[], { option: true }],
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 
 test('intercepts a GET request', async ({ network, page }) => {

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -1,13 +1,27 @@
 import { test as testBase, expect } from '@playwright/test'
-import { http, HttpResponse } from 'msw'
-import { createNetworkFixture, type NetworkFixture } from '../src/index.js'
+import { http, HttpResponse, type AnyHandler } from 'msw'
+import { defineNetworkFixture, type NetworkFixture } from '../src/fixture.js'
 
 interface Fixtures {
+  handlers: Array<AnyHandler>
   network: NetworkFixture
 }
 
 const test = testBase.extend<Fixtures>({
-  network: createNetworkFixture(),
+  handlers: [[], { option: true }],
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 
 test('mocks a response without any body', async ({ network, page }) => {

--- a/tests/skip-asset-requests.test.ts
+++ b/tests/skip-asset-requests.test.ts
@@ -1,13 +1,27 @@
 import { test as testBase, expect } from '@playwright/test'
-import { http, HttpResponse } from 'msw'
-import { createNetworkFixture, type NetworkFixture } from '../src/index.js'
+import { http, HttpResponse, type AnyHandler } from 'msw'
+import { defineNetworkFixture, type NetworkFixture } from '../src/index.js'
 
 interface Fixtures {
+  handlers: Array<AnyHandler>
   network: NetworkFixture
 }
 
 const test = testBase.extend<Fixtures>({
-  network: createNetworkFixture(),
+  handlers: [[], { option: true }],
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 
 test('skips asset requests by default', async ({ network, page }) => {
@@ -19,17 +33,29 @@ test('skips asset requests by default', async ({ network, page }) => {
 
   await page.goto('/')
   const responseBody = await page.evaluate(async () => {
-    const res = await fetch('/index.html')
-    return res.text()
+    const response = await fetch('/index.html')
+    return response.text()
   })
 
   expect(responseBody).toContain('<!DOCTYPE html')
 })
 
 const testWithAssets = testBase.extend<Fixtures>({
-  network: createNetworkFixture({
-    skipAssetRequests: false,
-  }),
+  handlers: [[], { option: true }],
+  network: [
+    async ({ context, handlers }, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers,
+        skipAssetRequests: false,
+      })
+
+      await network.enable()
+      await use(network)
+      await network.disable()
+    },
+    { auto: true },
+  ],
 })
 
 testWithAssets(


### PR DESCRIPTION
Changes the public API to facilitate Playwright fixture's best practices. 