### PR TITLE
docs: fix typo in fixture comment

### DIFF
--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -32,7 +32,7 @@ export interface NetworkFixtureOptions {
   onUnhandledRequest?: UnhandledRequestStrategy
   /**
    * Skip common asset requests (e.g. `*.html`, `*.css`, `*.js`, etc).
-   * This improves performance for certian projects.
+   * This improves performance for certain projects.
    * @default true
    *
    * @see https://mswjs.io/docs/api/is-common-asset-request


### PR DESCRIPTION
## Summary
- Fix a typo in the `skipAssetRequests` option comment